### PR TITLE
fix callback handler cleanup

### DIFF
--- a/src/easy.cpp
+++ b/src/easy.cpp
@@ -486,6 +486,7 @@ void easy::handle_completion(const boost::system::error_code& err)
 
 	multi_registered_ = false;
 	io_service_.post(boost::bind(handler_, err));
+	handler_.clear();
 }
 
 void easy::init()


### PR DESCRIPTION
Make sure all handler instances are destroyed after completion. This
allows code to hold shared pointer to easy object inside it's
own completion functor:

``` C++
auto easy = std::make_shared<curl::easy>(multi);
// ...
easy->async_perform([easy](const boost::system::error_code& ec)
{
    // ...
});
```

Previously this code lead to memory leak because of circular shared pointers. After this fix the code works as expected.
